### PR TITLE
Fire before and after print events

### DIFF
--- a/dist/leaflet.easyPrint.js
+++ b/dist/leaflet.easyPrint.js
@@ -31,8 +31,9 @@ function printPage(){
 			htmlElementsToHide[i].className = htmlElementsToHide[i].className + ' _epHidden';
 		}
 	}
+	this.map.fire("beforePrint");
 	window.print();
-
+	this.map.fire("afterPrint");
 	if (this.elementsToHide){
 		var htmlElementsToHide = document.querySelectorAll(this.elementsToHide);  
 


### PR DESCRIPTION
By creating these events, this will make the plugin a lot more flexible. As a result, a developer shouldn't need to edit this plugin's code int order to extend its functionality. 

For instance, one way these events could be used is to dynamically create a legend for the map based on what is within the field of view when the print button is clicked. The elementsToHide functionality (if it weren't already built into this plugin) could be accomplished using these new events (shown below).


Using these new events:
```javascript
map.on('beforePrint', function() {
});

map.on('afterPrint', function() {
});
```
Example use case: Building a legend for printing based on what is within the Field of View
```javascript
map.on('beforePrint', function() {
	//Get visible markers within field of view

	//Build legend and attach to DOM for printing

});

map.on('afterPrint', function() {
    //Remove Legend created during beforePrint event
    
});
```

The current elementsToHide functionality - if it weren't already built into the plugin using the events
```javascript
map.on('beforePrint', function() {
        //Hiding unwanted elements
	var htmlElementsToHide = document.querySelectorAll('p, h2');  

	for (var i = 0; i < htmlElementsToHide.length; i++) {
		htmlElementsToHide[i].className = htmlElementsToHide[i].className + ' _epHidden';
	}

});

map.on('afterPrint', function() {
      //Showing the elements that were hidden during printing
      var htmlElementsToHide = document.querySelectorAll('p, h2');  

	for (var i = 0; i < htmlElementsToHide.length; i++) {
		htmlElementsToHide[i].className = htmlElementsToHide[i].className.replace(' _epHidden','');
	}
});
```
